### PR TITLE
Different names but same initials should generate different colours

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -60,7 +60,7 @@ export default {
       canvas.height = size;
       context = canvas.getContext("2d");
 
-      context.fillStyle = colours[colourIndex - 1];
+      context.fillStyle = colours[colourIndex];
       context.fillRect(0, 0, canvas.width, canvas.height);
       context.font = Math.round(canvas.width / 2) + "px Arial";
       context.textAlign = "center";

--- a/src/app.vue
+++ b/src/app.vue
@@ -35,6 +35,12 @@ export default {
         nameSplit = String(name)
         .toUpperCase()
         .split(' '),
+        charCodeSum = name
+          .split('')
+          .map((c) => {
+            return c.charCodeAt(0)
+          })
+        .reduce((a, b) => a + b, 0)
         initials, charIndex, colourIndex, canvas, context, dataURI;
 
       if (nameSplit.length == 1) {
@@ -47,8 +53,8 @@ export default {
         size = (size * window.devicePixelRatio);
       }
 
-      charIndex = (initials == '?' ? 72 : initials.charCodeAt(0)) - 64;
-      colourIndex = charIndex % 20;
+      charIndex = (initials == '?' ? 72 : charCodeSum) - 64;
+      colourIndex = charIndex % colours.length;
       canvas = document.createElement('canvas');
       canvas.width = size;
       canvas.height = size;


### PR DESCRIPTION
 Same initials generate same color

Usage scenario: I want to render an avatar for two items with different name, lets say "Bill" and "Bob". But I want them to have different colors for better distinction. Alas!

My approach is getting the char code for each character in the `name` string (map) and sum them up (reduce). Then use this sum value to get the colour index. I also took the liberty to modulo by `colours.length` instead of a fixed value. You know, in case the length ever changes.